### PR TITLE
For those curly brackets without EOL separator

### DIFF
--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -50,6 +50,7 @@ function Listener(options) {
     this.serviceSocket.setEncoding('ascii');
 
     this.serviceSocket.on("data", function (payload) {
+        payload = payload.replace(/\}\{/g, '}\n{');
         var info = payload.split('\n'), data;
 
         for (var index = 0; index < info.length; index++) {


### PR DESCRIPTION
Working on AIS feeds, I discovered some JSON lines are missing EOL separator in between. This diff fixs those lines